### PR TITLE
3.3.1 function behavior for null

### DIFF
--- a/src/Rystem.OpenAi.Api/Rystem.OpenAi.Api.csproj
+++ b/src/Rystem.OpenAi.Api/Rystem.OpenAi.Api.csproj
@@ -18,7 +18,7 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/KeyserDSoze/Rystem.OpenAi</RepositoryUrl>
 		<PackageId>Rystem.OpenAi</PackageId>
-		<Version>3.3.0</Version>
+		<Version>3.3.1</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<UserSecretsId>f8af9352-bb0e-40fc-a4e9-9b584f95729f</UserSecretsId>
@@ -35,7 +35,7 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Identity" Version="1.9.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.9" />
 		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.31.0" />
 		<PackageReference Include="Polly" Version="7.2.4" />
 		<PackageReference Include="System.Drawing.Common" Version="7.0.0" />

--- a/src/Rystem.OpenAi.Test/Functions/CarRequestModel.cs
+++ b/src/Rystem.OpenAi.Test/Functions/CarRequestModel.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Rystem.OpenAi.Test.Functions
 {

--- a/src/Rystem.OpenAi.Test/Functions/MapFunction.cs
+++ b/src/Rystem.OpenAi.Test/Functions/MapFunction.cs
@@ -4,6 +4,7 @@ using Rystem.OpenAi.Chat;
 
 namespace Rystem.OpenAi.Test.Functions
 {
+
     internal sealed class MapFunction : IOpenAiChatFunction
     {
         public const string NameLabel = "get_current_position";

--- a/src/Rystem.OpenAi.Test/Functions/NullFunction.cs
+++ b/src/Rystem.OpenAi.Test/Functions/NullFunction.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+using Rystem.OpenAi.Chat;
+
+namespace Rystem.OpenAi.Test.Functions
+{
+    internal sealed class NullFunction : IOpenAiChatFunction
+    {
+        public const string NameLabel = "get_current_cart";
+        public string Name => NameLabel;
+        private const string DescriptionLabel = "Get the current cart of your user";
+        public string Description => DescriptionLabel;
+        public Type Input => typeof(NullRequestModel);
+        public Task<object> WrapAsync(string message)
+        {
+            _ = System.Text.Json.JsonSerializer.Deserialize<NullRequestModel>(message);
+            return Task.FromResult(default(object));
+        }
+    }
+}

--- a/src/Rystem.OpenAi.Test/Functions/NullRequestModel.cs
+++ b/src/Rystem.OpenAi.Test/Functions/NullRequestModel.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Rystem.OpenAi.Test.Functions
+{
+    internal sealed class NullRequestModel
+    {
+        [JsonPropertyName("username")]
+        [JsonPropertyDescription("The username of the user.")]
+        [JsonRequired]
+        public string Username { get; set; }
+    }
+}

--- a/src/Rystem.OpenAi.Test/Rystem.OpenAi.Test.csproj
+++ b/src/Rystem.OpenAi.Test/Rystem.OpenAi.Test.csproj
@@ -12,11 +12,11 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="Xunit.DependencyInjection" Version="8.7.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.9" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="Xunit.DependencyInjection" Version="8.7.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Rystem.OpenAi.Test/Startup.cs
+++ b/src/Rystem.OpenAi.Test/Startup.cs
@@ -100,7 +100,8 @@ namespace Rystem.OpenAi.Test
                 .AddOpenAiChatFunction<WeatherFunction>()
                 .AddOpenAiChatFunction<AirplaneFunction>()
                 .AddOpenAiChatFunction<GroceryFunction>()
-                .AddOpenAiChatFunction<MapFunction>();
+                .AddOpenAiChatFunction<MapFunction>()
+                .AddOpenAiChatFunction<NullFunction>();
             var results = Task.WhenAll(tasks.Select(x => x.AsTask())).ConfigureAwait(false).GetAwaiter().GetResult();
             Assert.NotEmpty(results);
         }


### PR DESCRIPTION
#### Null behavior from Function framework
If you return from your WrapAsync null, the framework doesn't make another call to open ai and return immediately as finish reason "null".

For example if I create a "unuseful" function that returns always null.

    internal sealed class NullFunction : IOpenAiChatFunction
    {
        public const string NameLabel = "get_current_cart";
        public string Name => NameLabel;
        private const string DescriptionLabel = "Get the current cart of your user";
        public string Description => DescriptionLabel;
        public Type Input => typeof(NullRequestModel);
        public Task<object> WrapAsync(string message)
        {
            _ = System.Text.Json.JsonSerializer.Deserialize<NullRequestModel>(message);
            return Task.FromResult(default(object));
        }
    }

I can test the behavior, and I expect the finish reason as "null".

    var openAiApi = _openAiFactory.Create(name);
    Assert.NotNull(openAiApi.Chat);
    var response = await openAiApi.Chat
        .RequestWithUserMessage("My username is Keyser D. Soze and I want to know what I have in my cart.")
        .WithModel(ChatModelType.Gpt35Turbo_Snapshot)
        .WithAllFunctions()
        .ExecuteAsync(true);

    var function = response.Choices[0].Message.Function;
    Assert.NotNull(function);
    Assert.Contains("Keyser D. Soze", function.Arguments);
    Assert.Equal("null", response.Choices[0].FinishReason);