### PR TITLE
Downgrade Rystem.OpenAi and remove packaging item

### DIFF
--- a/src/Rystem.OpenAi/Rystem.OpenAi.csproj
+++ b/src/Rystem.OpenAi/Rystem.OpenAi.csproj
@@ -24,7 +24,6 @@
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <UserSecretsId>b0061d78-060a-4020-9298-82b4fd2c0821</UserSecretsId>
     </PropertyGroup>
-
     <ItemGroup>
         <None Update="openai.png">
             <Pack>True</Pack>

--- a/src/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -34,7 +34,7 @@
         </When>
         <When Condition=" '$(Configuration)'!='Debug' ">
             <ItemGroup>
-                <PackageReference Include="Rystem.OpenAi" Version="9.0.0" />
+                <PackageReference Include="Rystem.OpenAi" Version="4.0.0-alpha" />
             </ItemGroup>
         </When>
     </Choose>


### PR DESCRIPTION
Updated Rystem.PlayFramework.csproj to use Rystem.OpenAi 4.0.0-alpha instead of 9.0.0. Removed the None item group for openai.png from Rystem.OpenAi.csproj.

﻿# Description

> :memo: Please include a summary of the change. 
>  
> * Please also include relevant motivation and context.  
> * List any dependencies that are required for this change.  

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.