### PR TITLE
Update Rystem.PlayFramework version and fix BOM issue

### DIFF
--- a/src/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -19,7 +19,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/PlayFramework</RepositoryUrl>
         <PackageId>Rystem.PlayFramework</PackageId>
-        <Version>9.0.1-pre.1</Version>
+        <Version>9.0.2-pre.1</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     </PropertyGroup>


### PR DESCRIPTION
Updated the version of the Rystem.PlayFramework package from 9.0.1-pre.1 to 9.0.2-pre.1. Fixed the XML declaration in the Rystem.PlayFramework.csproj file by adding a non-printable character (likely a Byte Order Mark, BOM) at the beginning of the file.

﻿# Description

> :memo: Please include a summary of the change. 
>  
> * Please also include relevant motivation and context.  
> * List any dependencies that are required for this change.  

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.