### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/src/Rystem.OpenAi/Rystem.OpenAi.csproj
+++ b/src/Rystem.OpenAi/Rystem.OpenAi.csproj
@@ -19,7 +19,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/KeyserDSoze/Rystem.OpenAi</RepositoryUrl>
         <PackageId>Rystem.OpenAi</PackageId>
-        <Version>4.2.8</Version>
+        <Version>4.2.9</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <UserSecretsId>b0061d78-060a-4020-9298-82b4fd2c0821</UserSecretsId>
@@ -39,7 +39,7 @@
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.2" />
         <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.69.1" />
         <PackageReference Include="Polly" Version="8.5.2" />
-        <PackageReference Include="Rystem.DependencyInjection" Version="9.0.21" />
+        <PackageReference Include="Rystem.DependencyInjection" Version="9.0.23" />
         <PackageReference Include="System.Text.Json" Version="9.0.2" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Rystem.PlayFramework.Test.Api/Rystem.PlayFramework.Test.Api.csproj
+++ b/src/Rystem.PlayFramework.Test.Api/Rystem.PlayFramework.Test.Api.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-        <PackageReference Include="Scalar.AspNetCore" Version="2.0.24" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.0.26" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -19,7 +19,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/PlayFramework</RepositoryUrl>
         <PackageId>Rystem.PlayFramework</PackageId>
-        <Version>9.0.19</Version>
+        <Version>9.0.20</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     </PropertyGroup>
@@ -34,7 +34,7 @@
         </When>
         <When Condition=" '$(Configuration)'!='Debug' ">
             <ItemGroup>
-                <PackageReference Include="Rystem.OpenAi" Version="4.2.8" />
+                <PackageReference Include="Rystem.OpenAi" Version="4.2.9" />
             </ItemGroup>
         </When>
     </Choose>


### PR DESCRIPTION
Update package versions across multiple projects

- Bump `Rystem.OpenAi` from `4.2.8` to `4.2.9`
- Update `Rystem.DependencyInjection` from `9.0.21` to `9.0.23`
- Upgrade `Scalar.AspNetCore` from `2.0.24` to `2.0.26`
- Change `Rystem.PlayFramework` version from `9.0.19` to `9.0.20`

#### PR Classification
Version updates for several packages in the Rystem project.

#### PR Summary
This pull request updates the versions of multiple packages across the Rystem project files to ensure compatibility and access to the latest features. 
- `Rystem.OpenAi.csproj`: Updated `Rystem.OpenAi` from `4.2.8` to `4.2.9` and `Rystem.DependencyInjection` from `9.0.21` to `9.0.23`.
- `Rystem.PlayFramework.csproj`: Updated `Scalar.AspNetCore` from `2.0.24` to `2.0.26` and `Rystem.PlayFramework` from `9.0.19` to `9.0.20`.
